### PR TITLE
[feature] 멤버 등급 로직 구현

### DIFF
--- a/src/main/java/com/maptist/mappride/mappride/MapprideApplication.java
+++ b/src/main/java/com/maptist/mappride/mappride/MapprideApplication.java
@@ -2,7 +2,9 @@ package com.maptist.mappride.mappride;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class MapprideApplication {
 

--- a/src/main/java/com/maptist/mappride/mappride/config/data/DataInitializer.java
+++ b/src/main/java/com/maptist/mappride/mappride/config/data/DataInitializer.java
@@ -1,0 +1,55 @@
+package com.maptist.mappride.mappride.config.data;
+
+import com.maptist.mappride.mappride.grade.Grade;
+import com.maptist.mappride.mappride.grade.GradeRepository;
+import com.maptist.mappride.mappride.grade.GradeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements ApplicationRunner {
+
+    private final GradeService gradeService;
+    private final Environment environment;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        String ddlAuto = environment.getProperty("spring.jpa.hibernate.ddl-auto");
+
+        if ("create".equals(ddlAuto)) {
+            System.out.println("✅ ddl-auto가 create이므로 초기 데이터를 삽입합니다.");
+            // 데이터 삽입 코드 추가
+            Grade beginner = Grade.builder()
+                    .name("비기너")
+                    .reviewCnt(0)
+                    .build();
+
+            Grade bronze = Grade.builder()
+                    .name("브론즈")
+                    .reviewCnt(50)
+                    .build();
+
+            Grade silver = Grade.builder()
+                    .name("실버")
+                    .reviewCnt(100)
+                    .build();
+
+            Grade gold = Grade.builder()
+                    .name("골드")
+                    .reviewCnt(500)
+                    .build();
+
+            gradeService.save(beginner);
+            gradeService.save(bronze);
+            gradeService.save(silver);
+            gradeService.save(gold);
+
+        } else {
+            System.out.println("❌ ddl-auto가 create이 아님. 데이터 삽입을 건너뜁니다.");
+        }
+    }
+}

--- a/src/main/java/com/maptist/mappride/mappride/config/data/SchedulerConfiguration.java
+++ b/src/main/java/com/maptist/mappride/mappride/config/data/SchedulerConfiguration.java
@@ -1,0 +1,21 @@
+package com.maptist.mappride.mappride.config.data;
+
+import com.maptist.mappride.mappride.grade.GradeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SchedulerConfiguration {
+
+    private final GradeService gradeService;
+
+    @Scheduled(cron = "0 0 0 * * FRI") // 매주 금요일
+    //@Scheduled(cron = "*/10 * * * * *") // 10초 마다
+    public void runSetGrade(){
+        gradeService.setGrade();
+    }
+}

--- a/src/main/java/com/maptist/mappride/mappride/grade/Grade.java
+++ b/src/main/java/com/maptist/mappride/mappride/grade/Grade.java
@@ -5,10 +5,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Grade {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/maptist/mappride/mappride/grade/GradeRepository.java
+++ b/src/main/java/com/maptist/mappride/mappride/grade/GradeRepository.java
@@ -1,0 +1,35 @@
+package com.maptist.mappride.mappride.grade;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class GradeRepository {
+
+    private final EntityManager em;
+
+    public Long create(Grade grade){
+        em.persist(grade);
+        return grade.getId();
+    }
+
+    public Grade findBeginner(){
+        String name = "비기너";
+        return em.createQuery("select g " +
+                        "from Grade g " +
+                        "where g.name =: name", Grade.class)
+                .setParameter("name", name)
+                .getSingleResult();
+    }
+
+    public List<Grade> findAll(){
+        return em.createQuery("select g " +
+                        "from Grade g " +
+                        "order by g.reviewCnt asc ",Grade.class)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/maptist/mappride/mappride/grade/GradeService.java
+++ b/src/main/java/com/maptist/mappride/mappride/grade/GradeService.java
@@ -1,0 +1,41 @@
+package com.maptist.mappride.mappride.grade;
+
+import com.maptist.mappride.mappride.member.Member;
+import com.maptist.mappride.mappride.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GradeService {
+
+    private final MemberRepository memberRepository;
+    private final GradeRepository gradeRepository;
+
+
+    public void setGrade() {
+
+        List<Member> memberList = memberRepository.findAll();
+        List<Grade> gradeList = gradeRepository.findAll();
+        for(Member m : memberList){
+            int scrapCnt = m.getScrapCnt();
+            Grade newGrade = null;
+           for(Grade g : gradeList){
+               if(scrapCnt >= g.getReviewCnt()){
+                   newGrade = g;
+               } else{
+                   break;
+               }
+           }
+           if(newGrade != null) m.updateGrade(newGrade);
+        }
+    }
+
+    public Long save(Grade grade){
+        return gradeRepository.create(grade);
+    }
+}

--- a/src/main/java/com/maptist/mappride/mappride/member/Member.java
+++ b/src/main/java/com/maptist/mappride/mappride/member/Member.java
@@ -13,6 +13,7 @@ import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDate;
@@ -51,19 +52,21 @@ public class Member {
     @Column(nullable = false)
     private int scrapCnt;
 
-    private Member(String email, String name, String userRole){
+    private Member(String email, String name, String userRole, Grade beginner){
         this.email = email;
         this.name = name;
         this.userRole = userRole;
         this.scrapCnt = 0;
         this.publish = false;
+        this.grade = beginner;
     }
 
-    public static Member createMember(RegisterDto registerDto){
+    public static Member createMember(RegisterDto registerDto, Grade beginner){
         Member member = new Member(
                 registerDto.getEmail(),
                 registerDto.getName(),
-                registerDto.getUserRole()
+                registerDto.getUserRole(),
+                beginner
         );
 
         return member;
@@ -72,4 +75,6 @@ public class Member {
     public void plusScrapCnt(){
         this.scrapCnt++;
     }
+
+    public void updateGrade(Grade grade) {this.grade = grade; }
 }

--- a/src/main/java/com/maptist/mappride/mappride/member/MemberRepository.java
+++ b/src/main/java/com/maptist/mappride/mappride/member/MemberRepository.java
@@ -146,4 +146,11 @@ public class MemberRepository {
     public void delete(Member member) {
         em.remove(member);
     }
+
+
+    public List<Member> findAll(){
+        return em.createQuery("select m " +
+                "from Member m", Member.class)
+                .getResultList();
+    }
 }

--- a/src/main/java/com/maptist/mappride/mappride/member/MemberService.java
+++ b/src/main/java/com/maptist/mappride/mappride/member/MemberService.java
@@ -9,6 +9,8 @@ import com.maptist.mappride.mappride.comment.Comment;
 import com.maptist.mappride.mappride.comment.CommentRepository;
 import com.maptist.mappride.mappride.config.jwt.DTO.SecurityUserDto;
 import com.maptist.mappride.mappride.config.s3.S3Service;
+import com.maptist.mappride.mappride.grade.Grade;
+import com.maptist.mappride.mappride.grade.GradeRepository;
 import com.maptist.mappride.mappride.member.DTO.MemberDto;
 import com.maptist.mappride.mappride.member.DTO.MemberEmailDto;
 import com.maptist.mappride.mappride.member.DTO.MemberNameDto;
@@ -43,13 +45,15 @@ public class MemberService {
     private final S3Service s3Service;
     private final PlaceRepository placeRepository;
     private final CategoryRepository categoryRepository;
+    private final GradeRepository gradeRepository;
 
     public Optional<Member> findByEmail(String email){
         return memberRepository.findByEmail(email);
     }
 
     public ResponseEntity<Long> register(RegisterDto registerDto) {
-        Member member = Member.createMember(registerDto);
+        Grade beginner = gradeRepository.findBeginner();
+        Member member = Member.createMember(registerDto, beginner);
 
         return ResponseEntity.ok().body(memberRepository.save(member));
     }


### PR DESCRIPTION
1. ddl-auto로 프로젝트를 빌드할 때마다 grade에 데이터 삽입(비기너, 브론즈, 실버, 골드)

2. 매주 금요일마다 모든 Member 의 ScrapCnt와 각 Grade의 ReviewCnt를 비교해 각 Member의 맞는 Grade 로 업데이트하는 스케쥴러 구현